### PR TITLE
Computational optimization: fit iEFC matrix to data, then fit Jacobian to iEFC matrix

### DIFF
--- a/corsid/iefc.py
+++ b/corsid/iefc.py
@@ -1,0 +1,136 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from numpy.typing import ArrayLike
+from scipy.optimize import minimize
+
+from corsid import util, batch_linalg as bl, differentiable as d, TrainingData
+from corsid.adam import AdamOptimizer
+from corsid.least_squares import estimate_states, eval_z_error, eval_dz_error, eval_dx_error
+
+log = logging.getLogger(__name__)
+jax.config.update('jax_enable_x64', True)
+
+
+@jax.jit
+def cost(G: np.ndarray, Psi: np.ndarray, A: np.ndarray):
+    """
+    Cost function that measures the fit between the Jacobian G, and the iEFC matrix, A:
+
+    ||A - H*G||^2
+
+    where H = 4(G*Psi).T.
+    """
+    G = G.astype(jnp.float64)
+    H = 4 * d.batch_mt(d.batch_mmip(G, Psi))
+
+    A_pred = d.batch_mmip(H, G)
+    A_err = A - A_pred
+    return d.l2sqr(A_err.ravel()) / d.l2sqr(A.ravel())
+
+@dataclass
+class FitToIEFCResult:
+    G: ArrayLike
+    costs: ArrayLike
+    dz_errors: ArrayLike
+    dx_errors: ArrayLike
+    z_errors: ArrayLike
+
+
+def fit_iefc_matrix(zs, us):
+    """
+    Calculate the iEFC matrix, given a time series of pairwise-probe data vectors (zs) and their
+    associated DM updates (us).
+    """
+    num_iter = len(zs.keys())
+
+    # Each z vector is shape (num_pix, num_probe).
+    # Stack into an array with shape (num_pix, num_probe, num_iter), interpreted as a stack of
+    # (num_probe, num_iter) matrices.
+    dZ = np.stack([zs[k] - zs[k-1] for k in range(1, num_iter)], axis=-1)
+
+    # Stack the u vectors into a (num_act, num_iter) matrix
+    U = np.column_stack([us[k] for k in range(1, num_iter)])
+
+    # dZ = A*U, so A_hat = dZ * pinv(U), with dZ and A looped over pixels
+    return bl.batch_mmip(dZ, np.linalg.pinv(U))
+
+def fit_jacobian_to_iefc_matrix(
+        data: TrainingData,
+        G0: ArrayLike,
+        method='L-BFGS-B',
+        options: Dict = None,
+        tol=1e-3
+):
+    """
+    Two-step algorithm for estimating Jacobian matrix: calculate the iEFC matrix in closed form,
+    then fit the Jacobian to the iEFC matrix via numerical optimization.
+    """
+    if options is None:
+        options = {'disp': False, 'maxcor': 10, 'maxls': 100}
+
+    costs = []
+    z_errors = []
+    dx_errors = []
+    dz_errors = []
+
+    # Obtain iEFC matrix in closed form
+    A = fit_iefc_matrix(data.zs, data.us)
+
+    # Starting guess for optimizer, containing only the values that we are optimizing
+    starting_guess = {'G': G0.astype(np.float64)}
+    unpack = util.make_unpacker(starting_guess)
+
+    calls = 0  # Incremented every time cost function is evaluated
+
+    def cost_for_optimizer(x):
+        sol = unpack(x)
+        G = sol['G']
+        J, grads = jax.value_and_grad(cost, argnums=(0,))(
+            G, data.Psi, A)
+        gradient = np.concatenate([np.array(grad).ravel() for grad in grads])
+        costs.append(J)
+        log.info(f'J: {J:0.3e}\t ||∂g|| = {np.linalg.norm(gradient):0.3e}')
+
+        # Evaluate quality-of-fit metrics
+        # Only do this after every 10 cost function evaluations to save time
+        nonlocal calls
+        calls += 1
+
+        if calls % 10 == 0:
+            H = 4 * bl.batch_mt(bl.batch_mmip(G, data.Psi))
+            xs = estimate_states(H, data.zs)
+
+            z_errors.append(eval_z_error(H, xs, data.zs))
+            dx_errors.append(eval_dx_error(G, xs, data.us))
+            dz_errors.append(eval_dz_error(G, H, data.us, data.zs))
+
+        return J, gradient
+
+    if method == 'adam':
+        adam = AdamOptimizer(cost_for_optimizer, x0=util.pack(starting_guess),
+                             num_iter=options['num_iter'],
+                             alpha=options['alpha'],
+                             beta1=options['beta1'],
+                             beta2=options['beta2'],
+                             eps=options['eps'])
+        Js, solution = adam.optimize()
+
+    else:
+        res = minimize(cost_for_optimizer, x0=util.pack(starting_guess), jac=True,
+                       method=method, options=options, tol=tol)
+        solution = res.x
+
+    result = FitToIEFCResult(
+        unpack(solution)['G'],
+        costs=np.array(costs),
+        dz_errors=np.array(dz_errors),
+        dx_errors=np.array(dx_errors),
+        z_errors=np.array(z_errors),
+    )
+
+    return result

--- a/corsid/iefc.py
+++ b/corsid/iefc.py
@@ -39,6 +39,7 @@ class FitToIEFCResult:
     dz_errors: ArrayLike
     dx_errors: ArrayLike
     z_errors: ArrayLike
+    val_errors: ArrayLike = None
 
 
 def fit_iefc_matrix(zs, us):
@@ -61,6 +62,7 @@ def fit_iefc_matrix(zs, us):
 
 def fit_jacobian_to_iefc_matrix(
         data: TrainingData,
+        validation_data: TrainingData,
         G0: ArrayLike,
         method='L-BFGS-B',
         options: Dict = None,
@@ -77,6 +79,7 @@ def fit_jacobian_to_iefc_matrix(
     z_errors = []
     dx_errors = []
     dz_errors = []
+    val_errors = []  # Same as dz_errors, but on validation data
 
     # Obtain iEFC matrix in closed form
     A = fit_iefc_matrix(data.zs, data.us)
@@ -108,6 +111,7 @@ def fit_jacobian_to_iefc_matrix(
             z_errors.append(eval_z_error(H, xs, data.zs))
             dx_errors.append(eval_dx_error(G, xs, data.us))
             dz_errors.append(eval_dz_error(G, H, data.us, data.zs))
+            val_errors.append(eval_dz_error(G, H, validation_data.us, validation_data.zs))
 
         return J, gradient
 
@@ -131,6 +135,7 @@ def fit_jacobian_to_iefc_matrix(
         dz_errors=np.array(dz_errors),
         dx_errors=np.array(dx_errors),
         z_errors=np.array(z_errors),
+        val_errors=np.array(val_errors)
     )
 
     return result

--- a/corsid/least_squares.py
+++ b/corsid/least_squares.py
@@ -136,9 +136,11 @@ class LeastSquaresIDResult:
     dz_errors: ArrayLike
     dx_errors: ArrayLike
     z_errors: ArrayLike
+    val_errors: ArrayLike = None
 
 def run_batch_least_squares_id(
         data: TrainingData,
+        validation_data: TrainingData,
         G0: ArrayLike,
         method='L-BFGS-B',
         options: Dict = None,
@@ -151,6 +153,7 @@ def run_batch_least_squares_id(
     dz_errors = []
     dx_errors = []
     z_errors = []
+    val_errors = []
 
     # Starting guess for optimizer, containing only the values that we are optimizing
     starting_guess = {'G': G0.astype(np.float64)}
@@ -175,6 +178,7 @@ def run_batch_least_squares_id(
         z_errors.append(eval_z_error(H, xs, data.zs))
         dx_errors.append(eval_dx_error(G, xs, data.us))
         dz_errors.append(eval_dz_error(G, H, data.us, data.zs))
+        val_errors.append(eval_dz_error(G, H, validation_data.us, validation_data.zs))
 
         log.info(f'J: {J:0.3e}\t ||∂g|| = {np.linalg.norm(gradient):0.3e}')
         return J, gradient
@@ -199,6 +203,7 @@ def run_batch_least_squares_id(
         dz_errors=np.array(dz_errors),
         dx_errors=np.array(dx_errors),
         z_errors=np.array(z_errors),
+        val_errors=np.array(val_errors)
     )
 
     return result
@@ -337,7 +342,8 @@ class StochasticLeastSquaresID:
                                       costs=np.array(self.costs),
                                       dz_errors=np.array(self.dz_errors),
                                       dx_errors=np.array(self.dx_errors),
-                                      z_errors=np.array(self.z_errors))
+                                      z_errors=np.array(self.z_errors),
+                                      val_errors=np.array(self.val_errors))
 
         return result
 

--- a/corsid/least_squares.py
+++ b/corsid/least_squares.py
@@ -295,7 +295,7 @@ class StochasticLeastSquaresID:
         ax.legend(loc='best')
 
         ax = axs[1]
-        ax.plot(np.arange(len(self.costs)), self.costs, 'o-')
+        ax.semilogy(np.arange(len(self.costs)), self.costs, 'o-')
         ax.set_xlabel('Epoch')
         ax.set_ylabel('Cost')
 


### PR DESCRIPTION
We currently fit the Jacobian $\Gamma$ directly to raw data via

$$
\hat{\Gamma} = \arg\min_{\Gamma} \sum_k\sum_{n}\lVert \Delta z_{k,n} - H_n\Gamma_n u_k \rVert^2
$$

where $n$ is the index for individual pixels.  This requires many passes over the data, and there are many more data points than tunable parameters, so optimization is very expensive computationally.

The iEFC matrix $H\Gamma$, on the other hand, can be solved directly from the data.  Let 

$$\begin{aligned}
U &= \begin{bmatrix} \cdots & u_k & \cdots \end{bmatrix} \\
\Delta Z_n &= \begin{bmatrix} \cdots  & \Delta z_{k,n} & \cdots \end{bmatrix} \\
A_n &\triangleq H_n\Gamma_n \\
\Delta Z &= A U \\
\hat{A}_n &= \Delta Z U^T(UU^T)^{-1}
\end{aligned}
$$

In terms of $A$, the optimization is straightforward:

$$
\begin{aligned}
\hat{\Gamma} &= \arg\min_{\Gamma} \sum_{n}\lVert A_n - H_n\Gamma_n \rVert^2 \\
&= \arg\min_{\Gamma} \sum_{n}\lVert A_n - \Psi^T\Gamma_n^T\Gamma_n \rVert^2 \\
\end{aligned}
$$

This PR implements a two-step fitting procedure for $\Gamma$: solve for $A$ in closed form, and then fit $\Gamma$ to $A$. This way, the data can be distilled down in a single operation to $A$, and numerical optimization to obtain $\Gamma$ then handles a much smaller problem size.  The second step can be done with L-BFGS very easily on a laptop, because we only have two matrices rather than all the training data.

@meiji274 and I have tested this with HiCAT data, and it results in a very large speedup: ~10 hours to <10 minutes when using 5,000 time steps of data.